### PR TITLE
updated the tiemout fix and changed the default to query last 24 hours

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,10 +1,10 @@
-NODE_ENV=production
-SOURCEMAP = false
+NODE_ENV=development
+SOURCEMAP = true
 
 # END POINTS #
 ORIGIN = ''
-API_EDP = ''
-ASSETS_HOST = ''
+API_EDP = 'https://openreplay.aven.com/api'
+ASSETS_HOST = 'https://aven-openreplay-assets.s3.us-east-2.amazonaws.com'
 
 # SENTRY
 SENTRY_ENABLED = false

--- a/frontend/app/duck/sessions.ts
+++ b/frontend/app/duck/sessions.ts
@@ -12,7 +12,7 @@ import {
   compareJsonObjects,
   cleanSessionFilters,
 } from 'App/utils';
-import { LAST_30_DAYS } from 'Types/app/period';
+import { LAST_24_HOURS } from 'Types/app/period';
 import { getDateRangeFromValue } from 'App/dateRange';
 import APIClient from 'App/api_client';
 import { FETCH_ACCOUNT, UPDATE_JWT } from 'Duck/user';
@@ -56,11 +56,16 @@ const SET_ACTIVE_TAB = 'sessions/SET_ACTIVE_TAB';
 const CLEAR_CURRENT_SESSION = 'sessions/CLEAR_CURRENT_SESSION';
 
 const range = getDateRangeFromValue(LAST_30_DAYS);
+const range = getDateRangeFromValue(LAST_24_HOURS);
 const defaultDateFilters = {
   url: '',
   rangeValue: LAST_30_DAYS,
   startDate: range.start.unix() * 1000,
   endDate: range.end.unix() * 1000,
+    url: '',
+    rangeValue: LAST_24_HOURS,
+    startDate: range.start.unix() * 1000,
+    endDate: range.end.unix() * 1000,
 };
 
 const initObj = {


### PR DESCRIPTION
Identified the issue is because of PostGres timeout by checking 500 http errors from backend.

manual request that timed out

curl -X POST 'https://openreplay.aven.com/api/2/sessions/search' -H 'Content-Type: application/json' --data '{"limit": 10, "page": 1, "events": [], "filters": [], "startDate": 1648044800000, "endDate": 1750723199000, "sort": "startTs", "order": "DESC", "events_order": "then", "group_by": null, "group_by_user": false, "bookmarked": false}'

On frontend also I added manual backedn 500 response it gets stuck in infinte loop attached recording


https://github.com/user-attachments/assets/f38dacfd-1bfe-400c-8ab5-d2795a50ddd0

