### PR TITLE
Add query params support to assist dashboard search

### DIFF
--- a/frontend/app/components/shared/LiveSessionSearch/LiveSessionSearch.tsx
+++ b/frontend/app/components/shared/LiveSessionSearch/LiveSessionSearch.tsx
@@ -4,24 +4,33 @@ import FilterSelection from 'Shared/Filters/FilterSelection';
 import { connect } from 'react-redux';
 import { Button } from 'UI';
 import { edit, addFilter } from 'Duck/liveSearch';
+import useSessionSearchQueryHandler from 'App/hooks/useSessionSearchQueryHandler';
 
 interface Props {
   appliedFilter: any;
   edit: typeof edit;
   addFilter: typeof addFilter;
   saveRequestPayloads: boolean;
+  loading?: boolean;
 }
 function LiveSessionSearch(props: Props) {
-  const { appliedFilter, saveRequestPayloads = false } = props;
-  const hasEvents = appliedFilter.filters.filter(i => i.isEvent).size > 0;
-  const hasFilters = appliedFilter.filters.filter(i => !i.isEvent).size > 0;
+  const { appliedFilter, saveRequestPayloads = false, loading = false } = props;
+  const hasEvents = appliedFilter.filters.filter((i: any) => i.isEvent).size > 0;
+  const hasFilters = appliedFilter.filters.filter((i: any) => !i.isEvent).size > 0;
 
-  const onAddFilter = (filter) => {
+  // Handle URL query parameters
+  useSessionSearchQueryHandler({
+    appliedFilter,
+    applyFilter: props.edit,
+    loading,
+  });
+
+  const onAddFilter = (filter: any) => {
     props.addFilter(filter);
   }
 
-  const onUpdateFilter = (filterIndex, filter) => {
-    const newFilters = appliedFilter.filters.map((_filter, i) => {
+  const onUpdateFilter = (filterIndex: any, filter: any) => {
+    const newFilters = appliedFilter.filters.map((_filter: any, i: any) => {
       if (i === filterIndex) {
         return filter;
       } else {
@@ -35,8 +44,8 @@ function LiveSessionSearch(props: Props) {
     });
   }
 
-  const onRemoveFilter = (filterIndex) => {
-    const newFilters = appliedFilter.filters.filter((_filter, i) => {
+  const onRemoveFilter = (filterIndex: any) => {
+    const newFilters = appliedFilter.filters.filter((_filter: any, i: any) => {
       return i !== filterIndex;
     });
 
@@ -45,7 +54,7 @@ function LiveSessionSearch(props: Props) {
     });
   }
 
-  const onChangeEventsOrder = (e, { name, value }) => {
+  const onChangeEventsOrder = (e: any, { name, value }: any) => {
     props.edit({
       eventsOrder: value,
     });
@@ -88,7 +97,8 @@ function LiveSessionSearch(props: Props) {
   ) : <></>;
 }
 
-export default connect(state => ({
+export default connect((state: any) => ({
   saveRequestPayloads: state.getIn(['site', 'active', 'saveRequestPayloads']),
   appliedFilter: state.getIn([ 'liveSearch', 'instance' ]),
+  loading: state.getIn(['liveSearch', 'fetchSessionListRequest', 'loading']) || false,
 }), { edit, addFilter })(LiveSessionSearch);


### PR DESCRIPTION
Links to assist dashboard now support query parameters so you can send pre-filtered results. For example:
`http://openreplay.aven.com/7/assist?os=is%7CAndroid&range=LAST_24_HOURS&sort=startTs&order=desc` 